### PR TITLE
fix(Dockerfile): use default name for build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM golang:1.15-alpine AS build-env
+FROM golang:1.15-alpine
 
 RUN apk update && apk upgrade && \
     apk add --no-cache git
 
-WORKDIR /  
+RUN mkdir ~/k8s-authz
+WORKDIR ~/k8s-authz  
 
 COPY go.mod .
 COPY go.sum .
@@ -11,11 +12,7 @@ RUN go mod download
 
 COPY . .
 
-RUN go build -o ./out/authz
+RUN go build -o ./authz
 
-COPY --from=build /out/authz /authz
-
-WORKDIR "/authz"
 EXPOSE 443
-
 CMD ["./authz"]


### PR DESCRIPTION
fix: #23

- remove custom build stage name `build-env`
- change workdir from `/` to `~/k8s-authz` 